### PR TITLE
Variable not found during import

### DIFF
--- a/src/utils/Config.py
+++ b/src/utils/Config.py
@@ -2,7 +2,7 @@ import json
 import os
 import ast
 
-from src.utils.util import make_exp_dir, save_file
+from src.utils.util import make_exp_dir
 
 class Config(object):
     def __init__(self, filename=None, kwargs=None, mkdir=True):


### PR DESCRIPTION
The `save_file` variable is not available in the `src.utils.util`, causing an error. The `save_file` variable isn't in this file, so I assumed it's unnecessary to import here (but perhaps it's being imported via this file from some other file in this project?).