### PR TITLE
Remove -p flag causing error

### DIFF
--- a/bin/train.sh
+++ b/bin/train.sh
@@ -3,6 +3,5 @@
 set -exu
 
 config_file=$1
-is_parallel=${2-False}
 
-python -m src.train -c $config_file -p $is_parallel
+python -m src.train -c $config_file


### PR DESCRIPTION
The `-p` flag does not seem to be implemented/supported by [train.py](https://github.com/rrmenon10/ADAPET/blob/master/src/train.py#L120), as far as I can tell (maybe the flag name was change to `-k` or something else?). This PR proposes to just remove the flag, which lets the code run for me (not sure if this causes something to break later on though, perhaps silently).

Here is the error I get from running the code as is:
```
> sh bin/train.sh config/BoolQ.json
+ config_file=config/BoolQ.json
+ is_parallel=False
+ python -m src.train -c config/BoolQ.json -p
usage: train.py [-h] -c CONFIG_FILE [-k [KWARGS [KWARGS ...]]]
train.py: error: unrecognized arguments: -p
```