### PR TITLE
NameError: name 'masked_words_text' is not defined

### DIFF
--- a/src/data/WSCReader.py
+++ b/src/data/WSCReader.py
@@ -111,7 +111,7 @@ class WSCReader(object):
                 words_text[pronoun_idx] = '*' + words_text[pronoun_idx] + '*'
                 text = ' '.join(words_text)
 
-                len_noun = max(len(self.tokenizer(masked_words_text[noun_idx], add_special_tokens=False)["input_ids"]), 1)
+                len_noun = max(len(self.tokenizer(words_text[noun_idx], add_special_tokens=False)["input_ids"]), 1)
                 len_pronoun = max(len(self.tokenizer(orig_text[pronoun_idx], add_special_tokens=False)["input_ids"]), 1)
 
                 dict_input = {"text": text, "pronoun": pronoun, "orig_text": orig_text,


### PR DESCRIPTION
When I run `sh bin/train.sh config/WSC.json`, I get the following error, coming from this file:
`NameError: name 'masked_words_text' is not defined`
 
Looking through the code, I see the related variable name `words_text`, which I assume is the intended variable for the current `masked_words_text` (though I could be wrong, please check me on this point). This commit replaces `masked_words_text` with `words_text`. When I make this fix, training on WSC continues without any Python error.

Below is the full trace:
```
> sh bin/train.sh config/WSC.json
+ config_file=config/WSC.json
+ is_parallel=False
+ python -m src.train -c config/WSC.json
Traceback (most recent call last):
  File "/home/ejp416/miniconda3/envs/adapet/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/home/ejp416/miniconda3/envs/adapet/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/ejp416/adapet/src/train.py", line 126, in <module>
    train(config)
  File "/home/ejp416/adapet/src/train.py", line 92, in train
    sup_batch = next(train_iter)
  File "/home/ejp416/adapet/src/data/Batcher.py", line 99, in get_train_batch
    self._init_train()
  File "/home/ejp416/adapet/src/data/Batcher.py", line 71, in _init_train
    train_data = self.dataset_reader.read_dataset("train")
  File "/home/ejp416/adapet/src/data/DatasetReader.py", line 61, in read_dataset
    return np.asarray(self.dataset_reader.read_dataset(split, is_eval))
  File "/home/ejp416/adapet/src/data/WSCReader.py", line 114, in read_dataset
    len_noun = max(len(self.tokenizer(masked_words_text[noun_idx], add_special_tokens=False)["input_ids"]), 1)
NameError: name 'masked_words_text' is not defined
```