### PR TITLE
Fix bug on COPA evaluation

### DIFF
--- a/src/adapet.py
+++ b/src/adapet.py
@@ -274,7 +274,7 @@ class adapet(torch.nn.Module):
 
                 log_probabilities.append(math.log(max_prob))
                 pet_mask_ids[idx][mask_pos] = masked_id
-                if isinstance(mask_pos, list):
+                if isinstance(mask_idx, list):
                     tok_pos = mask_idx[idx].index(mask_pos)
                 else:
                     tok_pos = torch.min(torch.nonzero(mask_idx[idx] == mask_pos)[0])


### PR DESCRIPTION
The COPA training process fails with the following exception.
```
Traceback (most recent call last):
  File "/opt/conda/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/opt/conda/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/workspace/adapet/src/train.py", line 135, in <module>
    train(config)
  File "/workspace/adapet/src/train.py", line 118, in train
    dev_acc, dev_logits = dev_eval(config, model, batcher, batch_idx, dict_avg_val)
  File "/workspace/adapet/src/eval/eval_model.py", line 65, in dev_eval
    eval(config, model, train_iter, train_scorer)
  File "/workspace/adapet/src/eval/eval_model.py", line 28, in eval
    pred_lbl, lbl_logits = model.predict(batch)
  File "/workspace/adapet/src/adapet.py", line 392, in predict
    return self.predict_helper(batch, self.get_pattern())
  File "/workspace/adapet/src/adapet.py", line 364, in predict_helper
    lbl_logits = self.get_eval_multilbl_logits(pet_mask_ids, mask_idx, list_lbl)
  File "/workspace/adapet/src/adapet.py", line 282, in get_eval_multilbl_logits
    tok_pos = torch.min(torch.nonzero(mask_idx[idx] == mask_pos)[0])
TypeError: nonzero() received an invalid combination of arguments - got (bool), but expected (Tensor input, *, bool as_tuple)
```
It causes the problem that the code checks data type on the wrong variable.
